### PR TITLE
Fixed Incorrect Bit Manipulation in MPU6050

### DIFF
--- a/Common/Mpu6050.hpp
+++ b/Common/Mpu6050.hpp
@@ -179,16 +179,10 @@ class Mpu6050 : public Accelerometer
                        { Value(RegisterMap::kDataConfig) }, &controlRegister,
                        1);
     auto sleepMask = bit::MaskFromRange(6);
-    // A value of 1 in bit 6 of the control register means the MPU6050 should be
-    // in sleep mode
-    if (is_active)
-    {
-      controlRegister = bit::Clear(controlRegister, sleepMask);
-    }
-    else
-    {
-      controlRegister = bit::Set(controlRegister, sleepMask);
-    }
+
+    // !is_active is required as the bit must be set to 0 in order to prevent it
+    // from sleeping.
+    controlRegister = bit::Insert(controlRegister, !is_active, sleepMask);
 
     // Write enable sequence
     Status status =


### PR DESCRIPTION
Fixed the issue with the bit masking by using the bit manipulation library. 
Fixed another issue where the MPU was put in sleep mode before setting the full scale range, causing it to not update the value.

Resolves SJSURoboticsTeam/urc-control_systems-2021#14