### PR TITLE
moves ServerTimeout logic within esp class

### DIFF
--- a/Arm/source/main.cpp
+++ b/Arm/source/main.cpp
@@ -53,14 +53,7 @@ int main()
       sjsu::LogInfo("Making new request...");
       std::string endpoint = "arm?example=1&param=2";  // include status updates
       std::string response = esp.GETRequest(endpoint);
-      sjsu::TimeoutTimer serverTimeout(5s);  // server has 5s timeout
       // Do stuff with arm here...
-      sjsu::Delay(3s);
-      if (serverTimeout.HasExpired())
-      {
-        sjsu::LogWarning("Server timed out! Reconnecting...");
-        esp.ConnectToServer();
-      }
     }
     catch (const std::exception & e)
     {

--- a/Drive/source/main.cpp
+++ b/Drive/source/main.cpp
@@ -1,6 +1,5 @@
 #include "utility/log.hpp"
 #include "peripherals/lpc40xx/can.hpp"
-#include "utility/time/timeout_timer.hpp"
 #include "devices/actuators/servo/rmd_x.hpp"
 
 #include "wheel.hpp"
@@ -63,15 +62,9 @@ int main(void)
       sjsu::LogInfo("Making new request...");
       std::string endpoint = drive.GETRequestParameters();
       std::string response = esp.GETRequest(endpoint);
-      sjsu::TimeoutTimer serverTimeout(5s);  // server has 5s timeout
       drive.ParseJSONResponse(response);
       drive.HandleRoverMovement();
       drive.PrintRoverData();
-      if (serverTimeout.HasExpired())
-      {
-        sjsu::LogWarning("Server timed out! Reconnecting...");
-        esp.ConnectToServer();
-      }
     }
     catch (const std::exception & e)
     {


### PR DESCRIPTION
This should simplify the code found within arm and drive main files. This logic should have been contained within the class from the beginning imo.