### PR TITLE
Fixed Units For Cleaner Code

### DIFF
--- a/Arm/joint.hpp
+++ b/Arm/joint.hpp
@@ -8,24 +8,13 @@ namespace sjsu::arm
 // the Joint class is used for the rotunda, elbow, and shoulder motors.
 class Joint
 {
- private:
-  // The minimum allowable angle the joint is able to turn to in normal
-  // operation.
-  units::angle::degree_t minimum_angle = 0_deg;
-  // The maximum allowable angle the joint is able to turn to in normal
-  // operation.
-  units::angle::degree_t maximum_angle = 180_deg;
-  // The angle the joint will move to when is not operational
-  units::angle::degree_t rest_angle = 0_deg;
-  // The angle between the motor's zero position and the actual homed zero
-  // positon.
-  units::angle::degree_t zero_offset_angle = 0_deg;
-  // Motor object that controls the joint
-  sjsu::RmdX & motor;
-  // accelerometer attached to the joint that is used to home the arm
-  sjsu::Mpu6050 & mpu;
-
- public:
+  public:
+  struct Acceleration
+  {
+    double x;
+    double y;
+    double z;
+  };
   Joint(sjsu::RmdX & joint_motor, sjsu::Mpu6050 & accelerometer)
       : motor(joint_motor), mpu(accelerometer)
   {
@@ -53,9 +42,10 @@ class Joint
   }
 
   /// Move the motor to the (calibrated) angle desired.
-  void SetPosition(units::angle::degree_t angle)
+  void SetPosition(double angle)
   {
-    units::angle::degree_t calibrated_angle = angle - zero_offset_angle;
+    units::angle::degree_t angle_to_degrees(angle);
+    units::angle::degree_t calibrated_angle = angle_to_degrees - zero_offset_angle;
     calibrated_angle                        = units::math::min(
         units::math::max(calibrated_angle, minimum_angle), maximum_angle);
     sjsu::LogInfo("%f", calibrated_angle.to<double>());
@@ -64,21 +54,48 @@ class Joint
 
   /// Sets the zero_offset_angle value that the motor uses to know its true '0'
   /// position. Called by RoverArmSystem::Home
-  void SetZeroOffset(units::angle::degree_t offset)
+  void SetZeroOffset(double offset)
   {
-    zero_offset_angle = offset;
+    units::angle::degree_t offset_to_degrees(offset);
+    zero_offset_angle = offset_to_degrees;
   }
 
-  /// Return the acceleration values for the MPU6050 on the joint.
-  sjsu::Accelerometer::Acceleration_t GetAccelerometerData()
+  /// Return the acceleration values for the MPU6050 on the joint as a JointAcceleration of doubles
+  JointAcceleration GetAccelerometerData()
   {
-    return mpu.Read();
+    sjsu::Accelerometer::Acceleration_t acceleration_to_double(mpu.Read());
+    JointAcceleration acceleration;
+    acceleration.y=static_cast<double>(acceleration_to_double.y);
+    acceleration.y=static_cast<double>(acceleration_to_double.y);
+    acceleration.z=static_cast<double>(acceleration_to_double.z);
+
+    return acceleration;
   }
-  void SetSpeed(units::angular_velocity::revolutions_per_minute_t speed)
+
+  void SetSpeed(double speed)
   {
-  speed_ = speed;
+  units::angular_velocity::revolutions_per_minute_t speed_to_rpm(speed);
+  speed_ = speed_to_rpm;
   motor.SetSpeed(speed_);
   }
-units::angular_velocity::revolutions_per_minute_t speed_;
+
+  private:
+  // The minimum allowable angle the joint is able to turn to in normal
+  // operation.
+  units::angle::degree_t minimum_angle = 0_deg;
+  // The maximum allowable angle the joint is able to turn to in normal
+  // operation.
+  units::angle::degree_t maximum_angle = 180_deg;
+  // The angle the joint will move to when is not operational
+  units::angle::degree_t rest_angle = 0_deg;
+  // The angle between the motor's zero position and the actual homed zero
+  // positon.
+  units::angle::degree_t zero_offset_angle = 0_deg;
+  // Motor object that controls the joint
+  sjsu::RmdX & motor;
+  // accelerometer attached to the joint that is used to home the arm
+  sjsu::Mpu6050 & mpu;
+  // speed of the joint motor
+  units::angular_velocity::revolutions_per_minute_t speed_;
 };
 }  // namespace sjsu::arm


### PR DESCRIPTION
Everything in this PR relates to cleaning up code via unit conversions:
-Changed all parameters of functions to doubles for cleaner code.
-Put all conversions into joint class instead of Rover_Arm_system.
-Moved private variables in the Joint class to the bottom.
-Added a structure of the accelerometer values as doubles instead of meters_per_second_squared.
-The GetAccelerometerValues now returns the structure Acceleration which consists of doubles to lessen the conversions and clean up code.